### PR TITLE
Remove noise from Politiken

### DIFF
--- a/src/JSInjection/Cleaning/Pages/politiken.js
+++ b/src/JSInjection/Cleaning/Pages/politiken.js
@@ -11,3 +11,11 @@ function removeSignUp(readabilityContent) {
   removeAllElementsIfExistent('[data-element-type="relation"]', div)
   return div.innerHTML;
 }
+
+export function cleanPolitikenBefore(documentClone) {
+  [".text-to-speech__disclaimer"].forEach((className) => {
+    removeAllElementsIfExistent(className, documentClone);
+  })
+  return documentClone;
+}
+

--- a/src/JSInjection/Cleaning/pageSpecificClean.js
+++ b/src/JSInjection/Cleaning/pageSpecificClean.js
@@ -16,7 +16,7 @@ import { cleanWyborcza, wyborczaRegex } from "./Pages/wyborcza";
 import { cleanRzecz, cleanRzeczBefore, rzeczRegex } from "./Pages/rzecz";
 import { cleanFaktBefore, faktRegex, removeFaktIFrames } from "./Pages/fakt";
 import { deleteIntervals, deleteTimeouts } from "../../popup/functions";
-import { politikenRegex, cleanPolitiken } from "./Pages/politiken";
+import { politikenRegex, cleanPolitiken, cleanPolitikenBefore } from "./Pages/politiken";
 import { scientiasRegex, cleanScientias } from "./Pages/scientias";
 import { egyszervoltRegex, cleanEgyszervolt } from "./Pages/egyszervolt";
 import { corriereRegex, removeCorriereScripts } from "./Pages/corriere";
@@ -54,7 +54,8 @@ export const cleanBeforeArray = [
   { regex: faktRegex, function: cleanFaktBefore },
   { regex: rzeczRegex, function: cleanRzeczBefore },
   { regex: lexpressRegex, function: cleanLexpressBefore },
-  { regex: marianneRegex, function: cleanMarianneBefore }
+  { regex: marianneRegex, function: cleanMarianneBefore },
+  { regex: politikenRegex, function: cleanPolitikenBefore }
 ];
 
 export const cleanAfterArray = [


### PR DESCRIPTION
I neglected this one you requested - here is the removing of noise from Politiken:
https://politiken.dk/udland/art8951008/Gazprom-sender-gas-til-Europa-via-Ukraine

Removing of the "reading out loud" text.

If you accept this one before the other one PR, we don't need to update the manifest version.