### PR TITLE
Moved preparing the article inside the UseEffect

### DIFF
--- a/src/JSInjection/ZeeguuError.js
+++ b/src/JSInjection/ZeeguuError.js
@@ -25,13 +25,12 @@ export default function ZeeguuError({
   const [feedbackSuccess, setFeedbackSuccess] = useState(false);
 
   useEffect(() => {
-    console.log("Inside Zeeguu error rendering.");
     const interval = setInterval(() => {
       if (timeout > 0) setTimeout(timeout - 1);
     }, 1000);
 
     if (isInternetDown) setReason(NO_INTERNET_CONNECTION);
-    else if (isMissingSession === undefined) setReason(SESSISON_FEEDBACK);
+    else if (isMissingSession) setReason(SESSISON_FEEDBACK);
     else if (isZeeguuAPIDown) setReason(API_DOWN_FEEDBACK);
     else if (isNotLanguageSupported) setReason(LANGUAGE_FEEDBACK);
     else if (isNotReadable) setReason(READABILITY_FEEDBACK);


### PR DESCRIPTION
+ I believe originally we moved the rendering of the article text to depend because I had observed that different articles would be rendered as the same article, but I don't see this anymore. This is a better pattern, we should only run that code once when the article is loaded.
+ Added a timeout error in the reader in case something goes wrong.
+ Some fixes to the ZeeguuError page